### PR TITLE
fix: two same block height on el when double propose

### DIFF
--- a/internal/blockchain/types.go
+++ b/internal/blockchain/types.go
@@ -107,6 +107,7 @@ type BlockProcessor struct {
 	metrics *metrics.BlockMetrics
 	client  EthClientInterface
 	logger  *logger.Logger
+	lastFoundELHeight int64
 }
 type EVMChainTx struct {
 	MsgType    uint32


### PR DESCRIPTION
This PR fixes an issue that is relevant for those who observe double supply on their validator, namely finding two same block height on EL when double propose.

Before:
```bash
{"time":"2024-11-20T22:12:16Z","level":"info","message":"ℹ️ Found validator block","data":{"height":7709338,"proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:17Z","level":"success","message":"✅ Found execution block","data":{"cl_height":7709338,"el_height":7127396,"hash":"0x123"}}
{"time":"2024-11-20T22:12:18Z","level":"debug","message":"Processing block","data":{"height":"7709339","proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:18Z","level":"info","message":"ℹ️ Found validator block","data":{"height":7709339,"proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:18Z","level":"success","message":"✅ Found execution block","data":{"cl_height":7709339,"el_height":7127396,"hash":"0x123"}}
```

After:
```bash
{"time":"2024-11-20T22:12:17Z","level":"info","message":"ℹ️ Found validator block","data":{"height":7709338,"proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:17Z","level":"success","message":"✅ Found execution block","data":{"cl_height":7709338,"el_height":7127396,"hash":"0x123"}}
{"time":"2024-11-20T22:12:18Z","level":"debug","message":"Processing block","data":{"height":"7709339","proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:18Z","level":"info","message":"ℹ️ Found validator block","data":{"height":7709339,"proposer_address":"ABCD"}}
{"time":"2024-11-20T22:12:19Z","level":"success","message":"✅ Found execution block","data":{"cl_height":7709339,"el_height":7127397,"hash":"0x123"}}
```